### PR TITLE
Update SettingController.php

### DIFF
--- a/settings/SettingController.php
+++ b/settings/SettingController.php
@@ -30,7 +30,9 @@ class SettingController extends Controller {
 			}
 		}
 		$this->settings = $settings;
-		$this->storageTypes = $settings['storageTypes'];
+		if(is_array($settings)) {
+			$this->storageTypes = $settings['storageTypes'];
+		}
 		$this->storagesDir = APP_PATH.'/config/.settings';
 	}
 	

--- a/uploader/UploadUcloud.php
+++ b/uploader/UploadUcloud.php
@@ -41,7 +41,8 @@ class UploadUcloud extends Upload{
         $this->proxySuffix = $ServerConfig['proxySuffix'];
         $this->bucket = $ServerConfig['bucket'];
         $this->endpoint = $ServerConfig['endpoint'] ?? '';
-	    $this->domain = $ServerConfig['domain'] ?? '';
+		$this->domain = $ServerConfig['domain'] ?? '';
+		$this->imgdomain = $ServerConfig['imgdomain'] ?? '';
 	    // http://markdown-blog.ufile.ucloud.com.cn
 	    $defaultDomain = 'http://' . $this->bucket . '.' . $this->endpoint;
 	    !$this->domain && $this->domain = $defaultDomain;
@@ -93,6 +94,14 @@ class UploadUcloud extends Upload{
 			list($data, $err) = UCloud_MFinish($this->bucket, $key, $data['UploadId'], $etagList);
 			if ($err) {
 				throw new Exception('UCloud_MFinish: '.var_export($err, true));
+			}
+
+			// 根据文件类型返回不同cdn域名
+			if ($this->imgdomain) {
+					$mimetype = exif_imagetype($uploadFilePath);
+				if ($mimetype == IMAGETYPE_GIF || $mimetype == IMAGETYPE_JPEG || $mimetype == IMAGETYPE_PNG || $mimetype == IMAGETYPE_BMP) {
+					$this->domain = $this->imgdomain;
+				}
 			}
 			
 			$data = [


### PR DESCRIPTION
#### fix bug on php 7.4
在我的 Mac 10.14.6上，通过brew安装php默认为最新版本，上传文件时，会触发 `php` 的一个 `notice`
> Notice: Trying to access array offset on value of type bool 

定位文件位置 `/PicUploader/settings/SettingController.php Line 33`

改动如下：
```php
if(is_array($settings)) {
    $this->storageTypes = $settings['storageTypes'];
}
```

其实就本身这个提示来说不是什么大问题，但是在自动粘贴的时候会附带两条这样的提示信息，影响使用。